### PR TITLE
Fixed endpoints for API connections

### DIFF
--- a/src/main/java/com/tabsnotspaces/match/MatchingController.java
+++ b/src/main/java/com/tabsnotspaces/match/MatchingController.java
@@ -115,7 +115,7 @@ public class MatchingController {
 		if(clientOpt.isPresent()) { // TODO report error otherwise
 			client = clientOpt.get();
 			// TODO check if consumer is present
-			
+			consumer.setParentClientId(id);
 			Consumer createdConsumer = consumerRepository.save(consumer);
 			client.getConsumers().add(consumer);
 			repository.save(client);
@@ -139,7 +139,8 @@ public class MatchingController {
 		Client client = null;
 		if(clientOpt.isPresent()) { // TODO report error otherwise
 			client = clientOpt.get();
-			// TODO check if service provider is present			
+			// TODO check if service provider is present
+			serviceProvider.setParentClientId(id);
 			ServiceProvider createdServiceProvider = serviceProviderRepository.save(serviceProvider);
 			client.getServiceProviders().add(serviceProvider);
 			repository.save(client);

--- a/src/main/resources/application-mysql.properties
+++ b/src/main/resources/application-mysql.properties
@@ -10,3 +10,4 @@ spring.datasource.password=password
 
 # Initialize the database since the newly created Cloud SQL database has no tables. The following flag is for Spring Boot 2.5+.
 #spring.sql.init.mode=always
+# Change ddl-auto to create-drop to reset database


### PR DESCRIPTION
previously required redundant fields to be filled in for client, service provider and consumer classes (eg. id, parentClientid), but now those fields can be omitted in POST request body)